### PR TITLE
Test record mode patch

### DIFF
--- a/snapshottest/error.py
+++ b/snapshottest/error.py
@@ -9,4 +9,4 @@ class SnapshotNotFound(SnapshotError):
     def __init__(self, module, test_name):
         super(SnapshotNotFound, self).__init__(
             "Snapshot '{snapshot_id!s}' not found in {snapshot_file!s}".format(
-                snapshot_id=test_name, snapshot_file=module.filepath))
+                snapshot_id=test_name, snapshot_file=module.storage.filepath))

--- a/snapshottest/module.py
+++ b/snapshottest/module.py
@@ -12,25 +12,20 @@ from .error import SnapshotNotFound
 
 logger = logging.getLogger(__name__)
 
-
-class SnapshotModule(object):
-    _snapshot_modules = {}
-
+class SnapshotModuleStorage(object):
     def __init__(self, module, filepath):
-        self._original_snapshot = None
-        self._snapshots = None
         self.module = module
         self.filepath = filepath
         self.imports = defaultdict(set)
-        self.visited_snapshots = set()
-        self.new_snapshots = set()
-        self.failed_snapshots = set()
         self.imports['snapshottest'].add('Snapshot')
+
+    @property
+    def snapshot_dir(self):
+        return os.path.dirname(self.filepath)
 
     def load_snapshots(self):
         try:
             source = imp.load_source(self.module, self.filepath)
-        # except FileNotFoundError:  # Python 3
         except (IOError, OSError) as err:
             if err.errno == errno.ENOENT:
                 return Snapshot()
@@ -40,16 +35,69 @@ class SnapshotModule(object):
             assert isinstance(source.snapshots, Snapshot)
             return source.snapshots
 
-    def visit(self, snapshot_name):
-        self.visited_snapshots.add(snapshot_name)
+    def save(self, last_snapshots):
+        # Create the snapshot dir in case doesn't exist
+        try:
+            os.makedirs(self.snapshot_dir, 0o0700)
+        except (IOError, OSError):
+            pass
 
-    def delete_unvisited(self):
-        for unvisited in self.unvisited_snapshots:
-            del self.snapshots[unvisited]
+        # Create __init__.py in case doesn't exist
+        open(os.path.join(self.snapshot_dir, '__init__.py'), 'a').close()
 
-    @property
-    def unvisited_snapshots(self):
-        return set(self.snapshots.keys()) - self.visited_snapshots
+        pretty = Formatter(self.imports)
+
+        with codecs.open(self.filepath, 'w', encoding="utf-8") as snapshot_file:
+            snapshots_declarations = []
+            for key, value in last_snapshots.items():
+                snapshots_declarations.append('''snapshots['{}'] = {}'''.format(key, pretty(value)))
+
+            imports = '\n'.join([
+                'from {} import {}'.format(module, ', '.join(sorted(module_imports)))
+                for module, module_imports in sorted(self.imports.items())
+            ])
+            snapshot_file.write('''# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+{}
+
+
+snapshots = Snapshot()
+
+{}
+'''.format(imports, '\n\n'.join(snapshots_declarations)))
+
+
+class SnapshotModulesRegistryMixin(object):
+    ''' Classmethods and class variable related to tracking all created
+        SnapshotModules.
+
+        Responsibilities:
+        * Creating SnapshotModule for given test filepath
+        * Count stats by SnapshotModule for pretty-printing '''
+
+    _snapshot_modules = {}
+
+    @classmethod
+    def get_module_for_testpath(cls, test_filepath):
+        if test_filepath not in cls._snapshot_modules:
+            dirname = os.path.dirname(test_filepath)
+            snapshot_dir = os.path.join(dirname, "snapshots")
+
+            snapshot_basename = 'snap_{}.py'.format(os.path.splitext(os.path.basename(test_filepath))[0])
+            snapshot_filename = os.path.join(snapshot_dir, snapshot_basename)
+            snapshot_module = '{}'.format(os.path.splitext(snapshot_basename)[0])
+
+            cls._snapshot_modules[test_filepath] = SnapshotModule(snapshot_module, snapshot_filename)
+
+        return cls._snapshot_modules[test_filepath]
+
+    # Stats
+
+    @classmethod
+    def get_modules(cls):
+        return SnapshotModule._snapshot_modules.values()
 
     @classmethod
     def total_unvisited_snapshots(cls):
@@ -62,15 +110,12 @@ class SnapshotModule(object):
 
         return unvisited_snapshots, unvisited_modules
 
-    @classmethod
-    def get_modules(cls):
-        return SnapshotModule._snapshot_modules.values()
 
     @classmethod
     def stats_for_module(cls, getter):
         count_snapshots = 0
         count_modules = 0
-        for module in SnapshotModule._snapshot_modules.values():
+        for module in cls.get_modules():
             length = getter(module)
             count_snapshots += length
             count_modules += min(length, 1)
@@ -103,10 +148,31 @@ class SnapshotModule(object):
     def has_snapshots(cls):
         return cls.stats_visited_snapshots()[0] > 0
 
+
+class SnapshotModule(SnapshotModulesRegistryMixin):
+    def __init__(self, module, filepath):
+        self._original_snapshot = None
+        self._snapshots = None
+        self.storage = SnapshotModuleStorage(module, filepath)
+        self.visited_snapshots = set()
+        self.new_snapshots = set()
+        self.failed_snapshots = set()
+
+    def visit(self, snapshot_name):
+        self.visited_snapshots.add(snapshot_name)
+
+    def delete_unvisited(self):
+        for unvisited in self.unvisited_snapshots:
+            del self.snapshots[unvisited]
+
+    @property
+    def unvisited_snapshots(self):
+        return set(self.snapshots.keys()) - self.visited_snapshots
+
     @property
     def original_snapshot(self):
         if not self._original_snapshot:
-            self._original_snapshot = self.load_snapshots()
+            self._original_snapshot = self.storage.load_snapshots()
         return self._original_snapshot
 
     @property
@@ -130,60 +196,12 @@ class SnapshotModule(object):
     def mark_failed(self, key):
         return self.failed_snapshots.add(key)
 
-    @property
-    def snapshot_dir(self):
-        return os.path.dirname(self.filepath)
-
     def save(self):
         if self.original_snapshot == self.snapshots:
             # If there are no changes, we do nothing
             return
-
-        # Create the snapshot dir in case doesn't exist
-        try:
-            os.makedirs(self.snapshot_dir, 0o0700)
-        except (IOError, OSError):
-            pass
-
-        # Create __init__.py in case doesn't exist
-        open(os.path.join(self.snapshot_dir, '__init__.py'), 'a').close()
-
-        pretty = Formatter(self.imports)
-
-        with codecs.open(self.filepath, 'w', encoding="utf-8") as snapshot_file:
-            snapshots_declarations = []
-            for key, value in self.snapshots.items():
-                snapshots_declarations.append('''snapshots['{}'] = {}'''.format(key, pretty(value)))
-
-            imports = '\n'.join([
-                'from {} import {}'.format(module, ', '.join(sorted(module_imports)))
-                for module, module_imports in sorted(self.imports.items())
-            ])
-            snapshot_file.write('''# -*- coding: utf-8 -*-
-# snapshottest: v1 - https://goo.gl/zC4yUc
-from __future__ import unicode_literals
-
-{}
-
-
-snapshots = Snapshot()
-
-{}
-'''.format(imports, '\n\n'.join(snapshots_declarations)))
-
-    @classmethod
-    def get_module_for_testpath(cls, test_filepath):
-        if test_filepath not in cls._snapshot_modules:
-            dirname = os.path.dirname(test_filepath)
-            snapshot_dir = os.path.join(dirname, "snapshots")
-
-            snapshot_basename = 'snap_{}.py'.format(os.path.splitext(os.path.basename(test_filepath))[0])
-            snapshot_filename = os.path.join(snapshot_dir, snapshot_basename)
-            snapshot_module = '{}'.format(os.path.splitext(snapshot_basename)[0])
-
-            cls._snapshot_modules[test_filepath] = SnapshotModule(snapshot_module, snapshot_filename)
-
-        return cls._snapshot_modules[test_filepath]
+        else:
+            self.storage.save(self.snapshots)
 
 
 class SnapshotTest(object):
@@ -195,6 +213,10 @@ class SnapshotTest(object):
 
     @property
     def module(self):
+        raise NotImplementedError("module property needs to be implemented")
+
+    @property
+    def record_mode(self):
         raise NotImplementedError("module property needs to be implemented")
 
     @property
@@ -231,22 +253,67 @@ class SnapshotTest(object):
     def assert_equals(self, value, snapshot):
         assert value == snapshot
 
+    def current_test_has_some_snapshots(self):
+        actually_test_name = self.test_name.split(' ')[0]
+        snapshot_keys = list(self.module.snapshots.keys())
+        same_test_snapshots = list(filter(
+            lambda x: x.startswith(actually_test_name), snapshot_keys
+        ))
+        return len(same_test_snapshots) > 0
+
+    def _try_to_match_snapshot(self, value, prev_snapshot):
+        try:
+            self.assert_value_matches_snapshot(value, prev_snapshot)
+        except AssertionError:
+            self.fail()
+            raise
+
+    def _fail_using_none_record_mode(self):
+        self.fail()
+        raise AssertionError(
+            'Received new snapshot %s, but `none` record mode '
+            'prohibits writing any new snapshots' 
+            % (self.test_name))
+
+    def _fail_using_once(self):
+        self.fail()
+        raise AssertionError(
+            'Received new snapshot %s, but current test already '
+            'has some snapshots, and current record mode `once` '
+            'allows writing snapshots only for new tests, having '
+            'no snapshots recorded' % (self.test_name)
+        )
+
+    def _snapshot_not_found(self, value):
+        if self.record_mode == 'none':
+            self._fail_using_none_record_mode()
+        elif self.record_mode == 'once':
+            if self.current_test_has_some_snapshots():
+                self._fail_using_once()
+            else:
+                # first time this test has been seen
+                self.store(value)
+        elif self.record_mode == 'new_interactions':
+            # first time this snapshot has been seen
+            self.store(value)
+        else:
+            raise RuntimeError(
+                'Record mode `%s` could not be handled' % (self.record_mode,)
+            )
+
     def assert_match(self, value, name=''):
         self.curr_snapshot = name or self.snapshot_counter
         self.visit()
-        if self.update:
+        if self.record_mode == 'all':
+            # On `all` record mode just rewrite snapshots no matter what
             self.store(value)
         else:
             try:
                 prev_snapshot = self.module[self.test_name]
             except SnapshotNotFound:
-                self.store(value)  # first time this test has been seen
+                self._snapshot_not_found(value)
             else:
-                try:
-                    self.assert_value_matches_snapshot(value, prev_snapshot)
-                except AssertionError:
-                    self.fail()
-                    raise
+                self._try_to_match_snapshot(value, prev_snapshot)
 
         if not name:
             self.snapshot_counter += 1

--- a/snapshottest/pytest.py
+++ b/snapshottest/pytest.py
@@ -9,17 +9,16 @@ from .reporting import reporting_lines, diff_report
 def pytest_addoption(parser):
     group = parser.getgroup('snapshottest')
     group.addoption(
-        '--snapshot-update',
-        action='store_true',
-        default=False,
-        dest='snapshot_update',
-        help='Update the snapshots.'
-    )
-    group.addoption(
         '--snapshot-verbose',
         action='store_true',
         default=False,
         help='Dump diagnostic and progress information.'
+    )
+    group.addoption(
+        '--snapshot-record-mode',
+        default='once',
+        choices=['none', 'once', 'new_interactions', 'all'],
+        help='Snapshot record mode.'
     )
 
 
@@ -35,7 +34,12 @@ class PyTestSnapshotTest(SnapshotTest):
 
     @property
     def update(self):
-        return self.request.config.option.snapshot_update
+        raise RuntimeError('Update option must not be used anymore')
+
+    @property
+    def record_mode(self):
+        return self.request.config.option.snapshot_record_mode
+
 
     @property
     def test_name(self):
@@ -74,11 +78,6 @@ def snapshot(request):
 
 
 def pytest_terminal_summary(terminalreporter):
-    if terminalreporter.config.option.snapshot_update:
-        for module in SnapshotModule.get_modules():
-            module.delete_unvisited()
-            module.save()
-
     terminalreporter.config._snapshotsession.display(terminalreporter)
 
 

--- a/snapshottest/reporting.py
+++ b/snapshottest/reporting.py
@@ -17,7 +17,7 @@ def reporting_lines(testing_cli):
             colored('{} snapshots written', 'green', attrs=bold) + ' in {} test suites.'
         ).format(*new_snapshots)
     inspect_str = colored(
-        'Inspect your code or run with `{} --snapshot-update` to update them.'.format(testing_cli),
+        'Inspect your code or run with `{} with less restrictive `--snapshot-record-mode` to update them.'.format(testing_cli),
         attrs=['dark']
     )
     failed_snapshots = SnapshotModule.stats_failed_snapshots()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,53 @@
+from snapshottest.module import SnapshotModule, SnapshotTest
+
+
+class GenericSnapshotTest(SnapshotTest):
+    """A concrete SnapshotTest implementation for no particular testing framework"""
+
+    def __init__(self, snapshot_module, update=False, current_test_id=None):
+        self._generic_options = {
+            'snapshot_module': snapshot_module,
+            'update': update,
+            'record_mode': 'all' if update else 'new_interactions',
+            'current_test_id': current_test_id or "test_mocked"}
+        super(GenericSnapshotTest, self).__init__()
+
+    @property
+    def module(self):
+        return self._generic_options["snapshot_module"]
+
+    @property
+    def update(self):
+        return self._generic_options["update"]
+
+    @property
+    def test_name(self):
+        return "{} {}".format(
+            self._generic_options["current_test_id"],
+            self.curr_snapshot)
+
+    @property
+    def record_mode(self):
+        return self._generic_options["record_mode"]
+
+    def reinitialize(self):
+        """Reset internal state, as though starting a new test run"""
+        super(GenericSnapshotTest, self).__init__()
+
+
+def assert_snapshot_test_ran(snapshot_test, test_name=None):
+    test_name = test_name or snapshot_test.test_name
+    assert test_name in snapshot_test.module.visited_snapshots
+
+
+def assert_snapshot_test_succeeded(snapshot_test, test_name=None):
+    test_name = test_name or snapshot_test.test_name
+    assert_snapshot_test_ran(snapshot_test, test_name)
+    assert test_name not in snapshot_test.module.failed_snapshots
+
+
+def assert_snapshot_test_failed(snapshot_test, test_name=None):
+    test_name = test_name or snapshot_test.test_name
+    assert_snapshot_test_ran(snapshot_test, test_name)
+    assert test_name in snapshot_test.module.failed_snapshots
+

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -11,7 +11,7 @@ class TestSnapshotModuleLoading(object):
         filepath = tmpdir.join("snap_new.py")
         assert not filepath.check()  # file does not exist
         module = SnapshotModule("tests.snapshots.snap_new", str(filepath))
-        snapshots = module.load_snapshots()
+        snapshots = module.storage.load_snapshots()
         assert isinstance(snapshots, Snapshot)
 
     def test_load_missing_package(self, tmpdir):
@@ -19,11 +19,11 @@ class TestSnapshotModuleLoading(object):
         filepath.write_text("import missing_package\n", "utf-8")
         module = SnapshotModule("tests.snapshots.snap_import", str(filepath))
         with pytest.raises(ImportError):
-            module.load_snapshots()
+            module.storage.load_snapshots()
 
     def test_load_corrupted_snapshot(self, tmpdir):
         filepath = tmpdir.join("snap_error.py")
         filepath.write_text("<syntax error>\n", "utf-8")
         module = SnapshotModule("tests.snapshots.snap_error", str(filepath))
         with pytest.raises(SyntaxError):
-            module.load_snapshots()
+            module.storage.load_snapshots()

--- a/tests/test_module_storage.py
+++ b/tests/test_module_storage.py
@@ -1,0 +1,65 @@
+import sys, os
+from contextlib import contextmanager
+
+import pytest
+
+from snapshottest.module import SnapshotModule
+
+# Helpers
+
+@contextmanager
+def add_to_sys_path(path: str):
+    full_path = os.path.abspath(path)
+    sys.path.append(full_path)
+    yield
+    sys.path.pop()
+
+# Test data
+
+TEST_SNAPSHOT_FILE = '''
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import Snapshot
+
+snapshots = Snapshot()
+snapshots['{snapshot_name}'] = '{snapshot_value}'
+'''
+
+# Fixtures
+
+@pytest.fixture()
+def filepath(tmpdir):
+    return tmpdir.join("snapshot_module.py")
+
+@pytest.fixture()
+def module(filepath):
+    return SnapshotModule("tests.snapshots.snapshot_module", str(filepath))
+
+# Tests
+
+def test_snapshot_save_works(module, tmpdir):
+    # Given: directly encodible value (formattin does not change it)
+    value = {'a': 1}
+    test_name = 'some test'
+    # When: add value for test_name and save
+    module[test_name] = value
+    module.save()
+    # Then: snapshot file actually contains of snapshot 
+    with add_to_sys_path(str(tmpdir)):
+        import snapshot_module
+    assert list(snapshot_module.snapshots.keys()) == [test_name]
+    assert snapshot_module.snapshots[test_name] == value
+
+def test_snapshot_load(module, filepath):
+    # Given: module associated to filled snapshot file
+    test_snapshot_file = TEST_SNAPSHOT_FILE.format(
+        snapshot_name='existing snapshot',
+        snapshot_value='value')
+    open(str(filepath), 'w').write(test_snapshot_file)
+    # Then: load_snapshots() loads snapshot from file
+    assert module.storage.load_snapshots()['existing snapshot'] == 'value'
+    # And: module works like load_snapshots()
+    assert module['existing snapshot'] == 'value'
+

--- a/tests/test_snapshot_record_mode.py
+++ b/tests/test_snapshot_record_mode.py
@@ -1,0 +1,85 @@
+from unittest.mock import Mock
+
+import pytest
+
+from snapshottest.module import SnapshotModule, SnapshotTest
+from tests.helpers import GenericSnapshotTest, assert_snapshot_test_succeeded, assert_snapshot_test_failed
+
+@pytest.fixture()
+def snapshot_module(tmpdir):
+    filepath = tmpdir.join("snap_mocked.py")
+    module = SnapshotModule("tests.snapshots.snap_mocked", str(filepath))
+    return module
+
+@pytest.fixture(name="snapshot_test")
+def fixture_snapshot_test(snapshot_module):
+    return GenericSnapshotTest(snapshot_module)
+
+# Behavior common for number of stragegies
+
+@pytest.mark.parametrize('record_mode', ['new_interactions', 'once', 'all'])
+def test_store_new_snapshot(snapshot_module, snapshot_test, record_mode):
+    snapshot_test._generic_options["record_mode"] = record_mode
+    snapshot_test.current_test_has_some_snapshots = Mock(return_value=False)
+    value = 1
+    # When: first run stores the value as the snapshot
+    snapshot_test.assert_match(value)
+    # Then
+    assert_snapshot_test_succeeded(snapshot_test)
+    # And
+    assert snapshot_module[snapshot_test.test_name] == value
+
+@pytest.mark.parametrize('record_mode', ['none', 'new_interactions', 'once'])
+def test_match_fail_on_existing_snapshot(
+        snapshot_module, snapshot_test, record_mode):
+    snapshot_test._generic_options["record_mode"] = record_mode
+    old_value = 1
+    new_value = 2
+    # Given: old_value already stored for `fixed` snapshot of test_mocked test
+    snapshot_test.curr_snapshot = 'fixed'
+    snapshot_test.store(old_value)
+    # When: we try to assert a new value for `fixed` snapshot
+    with pytest.raises(AssertionError):
+        snapshot_test.assert_match(new_value, name='fixed')
+    # Then
+    assert_snapshot_test_failed(snapshot_test)
+
+    
+# Behavior specific for strategies
+
+def test_match_works_on_existing_snapshot_for_all_record_mode(
+        snapshot_module, snapshot_test):
+    snapshot_test._generic_options["record_mode"] = 'all'
+    old_value = {'a': 1}
+    new_value = {'a': 2}
+    snapshot_test.assert_match(old_value, name='fixed')
+    # When:
+    snapshot_test.assert_match(new_value, name='fixed')
+    # Then
+    assert_snapshot_test_succeeded(snapshot_test)
+
+def test_match_fails_on_new_snapshot_for_none_record_mode(
+        snapshot_module, snapshot_test):
+    # Given: snapshot test has none starategy
+    snapshot_test._generic_options["record_mode"] = 'none'
+    value = 1
+    # When: first run stores the value as the snapshot
+    with pytest.raises(AssertionError):
+        snapshot_test.assert_match(value)
+    # Then
+    assert_snapshot_test_failed(snapshot_test)
+
+def test_match_fails_on_new_snapshot_in_recorded_test_for_once_record_mode(
+        snapshot_module, snapshot_test):
+    # Given: snapshot test has once starategy
+    snapshot_test._generic_options["record_mode"] = 'once'
+    value = 1
+    # Given: snashot test is mocked to say test has some snapshots
+    snapshot_test.current_test_has_some_snapshots = Mock(return_value=True)
+    # When: first run stores the value as the snapshot
+    with pytest.raises(AssertionError):
+        snapshot_test.assert_match(value)
+    # Then
+    assert_snapshot_test_failed(snapshot_test)
+
+# 

--- a/tests/test_snapshot_test.py
+++ b/tests/test_snapshot_test.py
@@ -1,54 +1,8 @@
 from __future__ import unicode_literals
 
 import pytest
-
-from snapshottest.module import SnapshotModule, SnapshotTest
-
-
-class GenericSnapshotTest(SnapshotTest):
-    """A concrete SnapshotTest implementation for no particular testing framework"""
-
-    def __init__(self, snapshot_module, update=False, current_test_id=None):
-        self._generic_options = {
-            'snapshot_module': snapshot_module,
-            'update': update,
-            'current_test_id': current_test_id or "test_mocked"}
-        super(GenericSnapshotTest, self).__init__()
-
-    @property
-    def module(self):
-        return self._generic_options["snapshot_module"]
-
-    @property
-    def update(self):
-        return self._generic_options["update"]
-
-    @property
-    def test_name(self):
-        return "{} {}".format(
-            self._generic_options["current_test_id"],
-            self.curr_snapshot)
-
-    def reinitialize(self):
-        """Reset internal state, as though starting a new test run"""
-        super(GenericSnapshotTest, self).__init__()
-
-
-def assert_snapshot_test_ran(snapshot_test, test_name=None):
-    test_name = test_name or snapshot_test.test_name
-    assert test_name in snapshot_test.module.visited_snapshots
-
-
-def assert_snapshot_test_succeeded(snapshot_test, test_name=None):
-    test_name = test_name or snapshot_test.test_name
-    assert_snapshot_test_ran(snapshot_test, test_name)
-    assert test_name not in snapshot_test.module.failed_snapshots
-
-
-def assert_snapshot_test_failed(snapshot_test, test_name=None):
-    test_name = test_name or snapshot_test.test_name
-    assert_snapshot_test_ran(snapshot_test, test_name)
-    assert test_name in snapshot_test.module.failed_snapshots
+from snapshottest.module import SnapshotModule
+from tests.helpers import GenericSnapshotTest, assert_snapshot_test_failed, assert_snapshot_test_succeeded
 
 
 @pytest.fixture(name="snapshot_test")


### PR DESCRIPTION
* Add record_mode functionality and tests to SnapshotModule
* Add record_mode functionality to pytest adapter, and break all others
* Split SnapshotModule into three classes
* Add tests for snapshot saving
* Separate helpers from tests
* Some other fixes